### PR TITLE
Fix incorrect license field in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-diataxis"
-version = "0.1.1"
+version = "0.1.0"
 edition = "2024"
 license = "GPL-3.0"
 description = "A preprocessor for mdBook which helps apply the Diátaxis documentation framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mdbook-diataxis"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
-license-file = "LICENSE"
+license = "GPL-3.0"
 description = "A preprocessor for mdBook which helps apply the Diátaxis documentation framework"
 repository = "https://github.com/TheSignPainter98/mdbook-diataxis"
 readme = "README.md"


### PR DESCRIPTION
This PR replaces the `license-file` with the `license` key which is currently causing `crates.io` to list this crate as under a non-standard license
